### PR TITLE
Add debug info for deployment package creation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,36 @@ jobs:
 
       - name: Prepare deployment package
         run: |
+        echo "Current directory contents before creating deployment_package:"
+          ls -la # <--- デバッグ情報追加: カレントディレクトリの内容を表示
+          echo "---"
+
+          mkdir deployment_package
+
+          echo "Copying .next directory..."
+          cp -R .next deployment_package/
+
+          echo "Checking for public directory..."
+          if [ -d "public" ]; then
+            echo "'public' directory found. Copying..."
+            cp -R public deployment_package/
+          else
+            echo "Warning: 'public' directory not found at $(pwd)/public. Skipping copy."
+          fi
+
+          echo "Copying package.json..."
+          cp package.json deployment_package/
+
+          echo "Copying pnpm-lock.yaml..."
+          cp pnpm-lock.yaml deployment_package/
+
+          echo "Copying next.config.mjs..."
+          cp next.config.mjs deployment_package/
+
+          echo "---"
+          echo "Contents of deployment_package:"
+          ls -la deployment_package/
+
           mkdir deployment_package
           cp -r .next deployment_package/
           cp -r public deployment_package/


### PR DESCRIPTION
This pull request includes updates to the deployment preparation step in the GitHub Actions workflow to improve debugging and handle missing directories more gracefully.

### Workflow improvements:

* Added debug logs to display the contents of the current directory before creating the `deployment_package` directory and after populating it. This helps in diagnosing issues during deployment preparation.
* Improved the script to check for the existence of the `public` directory before attempting to copy it, adding a warning message if the directory is missing. This prevents unnecessary errors during the workflow execution.