### PR TITLE
Hotfix: Correct ssh-deploy action version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,7 +85,7 @@ jobs:
             echo "Prerequisites validated successfully"
 
       - name: Deploy to EC2 via SSH and rsync
-        uses: easingthemes/ssh-deploy@v5.2.0
+        uses: easingthemes/ssh-deploy@v5.1.0
         with:
           sshPrivateKey: ${{ secrets.EC2_SSH_PRIVATE_KEY }}
           remoteHost: ${{ secrets.EC2_HOST }}


### PR DESCRIPTION
## Issue
- Deployment workflow failing due to non-existent ssh-deploy@v5.2.0 version

## Purpose  
- 緊急修正: GitHub Actions ワークフローがバージョン解決エラーで失敗している問題を修正

## Changes
- ssh-deploy アクションのバージョンを v5.2.0 → v5.1.0 に修正
- v5.1.0 が実際に利用可能な最新バージョン

## Results
- ワークフローのバージョン解決エラーが解消
- デプロイ自動化が正常に実行可能になる