### PR TITLE
fix(ci): update SSH deploy action parameter names to uppercase

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,12 +87,12 @@ jobs:
       - name: Deploy to EC2 via SSH and rsync
         uses: easingthemes/ssh-deploy@v5.1.0
         with:
-          sshPrivateKey: ${{ secrets.EC2_SSH_PRIVATE_KEY }}
-          remoteHost: ${{ secrets.EC2_HOST }}
-          remoteUser: ${{ secrets.EC2_USER }}
-          source: 'deployment_package/*'
-          target: ${{ secrets.EC2_TARGET }}
-          args: '-avz --delete'
+          SSH_PRIVATE_KEY: ${{ secrets.EC2_SSH_PRIVATE_KEY }}
+          REMOTE_HOST: ${{ secrets.EC2_HOST }}
+          REMOTE_USER: ${{ secrets.EC2_USER }}
+          SOURCE: 'deployment_package/*'
+          TARGET: ${{ secrets.EC2_TARGET }}
+          ARGS: '-avz --delete'
 
       - name: Execute remote commands on EC2
         uses: appleboy/ssh-action@v1.0.3


### PR DESCRIPTION
## Issue
- 

## Purpose
- GitHub ActionsのデプロイステップでSSH deployアクションが失敗していた問題を修正
- easingthemes/ssh-deploy@v5.1.0が期待するパラメータ名に合わせて修正

## Changes
- `.github/workflows/main.yml`のSSH deployアクションのパラメータ名を変更:
  - `sshPrivateKey` → `SSH_PRIVATE_KEY`
  - `remoteHost` → `REMOTE_HOST`
  - `remoteUser` → `REMOTE_USER`
  - `source` → `SOURCE`
  - `target` → `TARGET`
  - `args` → `ARGS`

## Results
- デプロイアクションが正しくパラメータを認識するようになり、デプロイが成功するようになる

🤖 Generated with [Claude Code](https://claude.ai/code)