### PR TITLE
fix(ci): remove duplicate pull_request_target trigger

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -3,8 +3,6 @@ name: PR Validation
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  pull_request_target:
-    types: [opened, synchronize, reopened]
 
 jobs:
   validate-pr:


### PR DESCRIPTION
## Issue
- closes #44

## Purpose
- CIワークフローが重複実行される問題を修正するため
- PR検証ワークフローで pull_request と pull_request_target の両方のトリガーが設定されており、同じイベントで2回実行されていた

## Changes
- .github/workflows/pr-validation.yml から pull_request_target トリガーを削除
- pull_request トリガーのみを使用するように修正

## Results
- PR作成・更新時のCI実行が1回のみになり、重複実行が解消される
- 検証に必要な権限は pull_request トリガーで十分であることを確認

## Tests
- ワークフロー設定の構文チェック完了
- 本PRでの実際の動作確認予定