### PR TITLE
fix(ci): Prevent duplicate comments in Dependabot workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -112,6 +112,25 @@ jobs:
             const updateType = '${{ steps.dependabot-metadata.outputs.update-type }}';
             const dependencyNames = '${{ steps.dependabot-metadata.outputs.dependency-names }}';
 
+            // Check for existing comments to prevent duplicates
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+
+            // Look for existing bot comment about manual review
+            const existingComment = comments.find(comment => 
+              comment.user.type === 'Bot' && 
+              comment.body.includes('🔍 Manual Review Required') &&
+              comment.body.includes(dependencyNames)
+            );
+
+            if (existingComment) {
+              console.log('Manual review comment already exists, skipping duplicate comment');
+              return;
+            }
+
             const comment = `## 🔍 Manual Review Required
 
             This Dependabot PR requires manual review because:
@@ -122,9 +141,11 @@ jobs:
 
             Please review the changes and merge manually if appropriate.`;
 
-            github.rest.issues.createComment({
+            await github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: comment
             });
+
+            console.log('Posted manual review comment for major version update');


### PR DESCRIPTION
## Issue
- Fixes endless communication loop seen in PRs like #57

## Purpose
- Prevent duplicate "Manual Review Required" comments when Dependabot PRs are rebased
- Stop the spam of identical comments on major version update PRs

## Changes
- **Added duplicate comment detection**
  - Check for existing bot comments before posting new ones
  - Look for comments containing "🔍 Manual Review Required" and the dependency name
  - Skip posting if a matching comment already exists
  
- **Improved logging**
  - Log when skipping duplicate comments
  - Log when posting new manual review comments

## Results
- Major version update PRs will only get one manual review comment
- Rebasing or synchronizing PRs won't trigger duplicate comments
- Cleaner PR comment history without spam

## How It Works
1. When workflow runs on `synchronize` events (PR updates/rebases)
2. It fetches all existing comments on the PR
3. Checks if a manual review comment already exists for the dependency
4. Only posts a new comment if none exists

This maintains the notification functionality while preventing the endless loop.

🤖 Generated with [Claude Code](https://claude.ai/code)