### PR TITLE
docs: update portfolio page with recent experience and skills

### DIFF
--- a/app/portfolio/page.tsx
+++ b/app/portfolio/page.tsx
@@ -9,7 +9,7 @@ export default function Page() {
     <section>
       <h1 className='text-2xl font-semibold tracking-tighter'>Portfolio</h1>
       <p className='mb-6 text-sm text-neutral-500 dark:text-neutral-400'>
-        Last Updated: May 7, 2025
+        Last Updated: September 2, 2025
       </p>
 
       <div className='mb-8'>
@@ -47,7 +47,7 @@ export default function Page() {
         <h3 className='font-medium mb-2'>Programming Languages:</h3>
         <ul className='list-disc pl-5 mb-4 text-neutral-700 dark:text-neutral-300'>
           <li>
-            Ruby: 10 months (Experience in web application development in a
+            Ruby: 1 year (Experience in web application development in a
             professional setting)
           </li>
           <li>JavaScript: 1 year 6 months (Capable of basic programming)</li>
@@ -69,13 +69,16 @@ export default function Page() {
           </li>
           <li>CUDA: 6 months (Capable of basic programming)</li>
           <li>C: 6 months (Capable of basic programming)</li>
+          <li>
+            TypeScript: 4 months (Reference-based implementation capabilities)
+          </li>
         </ul>
 
         <h3 className='font-medium mb-2'>Frameworks/Libraries:</h3>
         <ul className='list-disc pl-5 mb-4 text-neutral-700 dark:text-neutral-300'>
           <li>
-            Ruby on Rails: 10 months (Experience in web application development
-            in a professional setting)
+            Ruby on Rails: 1 year (Experience in web application development in
+            a professional setting)
           </li>
           <li>
             Next.js: 2 months (Capable of implementing basic applications;
@@ -85,11 +88,12 @@ export default function Page() {
             DirectX 12: 1 year (Capable of implementing applications including
             environment setup and GUI)
           </li>
+          <li>React: 4 months (Reference-based implementation capabilities)</li>
         </ul>
 
         <h3 className='font-medium mb-2'>Databases:</h3>
         <ul className='list-disc pl-5 mb-4 text-neutral-700 dark:text-neutral-300'>
-          <li>MySQL: 10 months (Experience using in a professional setting)</li>
+          <li>MySQL: 1 year (Experience using in a professional setting)</li>
           <li>
             PostgreSQL: 2 months (Capable from installation to table creation)
           </li>
@@ -99,7 +103,7 @@ export default function Page() {
         <h3 className='font-medium mb-2'>Cloud Platforms:</h3>
         <ul className='list-disc pl-5 mb-4 text-neutral-700 dark:text-neutral-300'>
           <li>
-            AWS: 1 year 6 months (Experience building and operating in a
+            AWS: 2 years 6 months (Experience building and operating in a
             professional setting)
           </li>
           <li>GCP (BigQuery): 3 months (Experience using APIs)</li>
@@ -417,7 +421,11 @@ export default function Page() {
             March 2024: Completed Hokkaido University, Graduate School of
             Information Science and Technology
           </li>
-          <li>Major: Information science</li>
+          <li>
+            Major: Advanced communication technologies such as optical and
+            wireless communication, and multimedia information science including
+            AI and CG.
+          </li>
         </ul>
 
         <h2 className='text-lg font-medium mb-3'>Licenses & Certifications</h2>
@@ -426,6 +434,7 @@ export default function Page() {
             Regular Passenger Vehicle Driver's License (Class 1) (Acquired June
             2020)
           </li>
+          <li>TOEIC® Listening & Reading Test 725 points (July 2018)</li>
         </ul>
 
         <h2 className='text-lg font-medium mb-3'>Awards & Presentations</h2>


### PR DESCRIPTION
## Issue
- 

## Purpose
- ポートフォリページの情報を最新の経験とスキルに更新し、より正確で包括的な職歴・技術経験を反映する

## Changes
- 最終更新日を2025年9月2日に更新
- プログラミング言語の経験年数を更新（Ruby, MySQL等を1年に）
- TypeScriptとReactの経験を追加（4ヶ月の経験）
- AWSの経験年数を2年6ヶ月に更新
- 専攻分野の詳細な説明を追加（光・無線通信技術、AI・CG等のマルチメディア情報科学）
- TOEIC®スコア（725点）を資格・認定に追加

## Results
- より正確で最新の技術スキルと経験年数が反映されたポートフォリオページ
- 追加された技術スキル（TypeScript, React）により幅広い開発経験をアピール
- 詳細な専攻情報により学術的背景をより明確に表示

## Tests
- 既存のコンテンツ表示に影響なし